### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:latest
+FROM gcc:10.3-buster
 
 # Install necessary packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 
 # Credit: https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
 # Install `gosu` to avoid running as root.
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN gpg --keyserver keyserver.insect.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture)" \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture).asc" \
     && gpg --verify /usr/local/bin/gosu.asc \


### PR DESCRIPTION
These updates fix two problems with the Dockerfile:

1. The previous keyserver [is no longer online](https://bugs.archlinux.org/task/71078) so I updated it to a new one.
2. The `gcc:latest` Docker image does not have some of the packages we need since it has been updated to Debian Bullseye. I changed the base to `gcc:10.3-buster`.